### PR TITLE
Migrating from master/slave phrasing

### DIFF
--- a/app/my.py
+++ b/app/my.py
@@ -27,9 +27,9 @@ def cluster_summary(config_file):
 
     :param config_file: A configuration file containing the cluster(s) definition
     """
-    cluster_dict = { "master": 0,
-                     "master_slave": 0,
-                     "slave": 0,
+    cluster_dict = { "main": 0,
+                     "main_subordinate": 0,
+                     "subordinate": 0,
                      "backup": 0 }
     config = ConfigParser.ConfigParser()
     config.read(config_file)

--- a/pymy/MySQLServer.py
+++ b/pymy/MySQLServer.py
@@ -48,7 +48,7 @@ class MySQLServer:
             result = cursor.fetchone()
             return result[1]
 
-    def show_slave_status(self, connection):
+    def show_subordinate_status(self, connection):
         """
         Execute the "SHOW SLAVE STATUS" command
         :param connection:
@@ -60,7 +60,7 @@ class MySQLServer:
             result = cursor.fetchall()
             return result
 
-    def show_master_status(self, connection):
+    def show_main_status(self, connection):
         """
         Execute the "SHOW MASTER STATUS" command
         :param connection:

--- a/tests/test_MySQLServer.py
+++ b/tests/test_MySQLServer.py
@@ -25,14 +25,14 @@ class MyTest(unittest.TestCase):
         o = int(m.query_global_variables(m.connection, "INNODB_BUFFER_POOL_INSTANCES"))
         self.assertTrue(isinstance(o, int) and o > 0)
 
-    def test_show_slave_status(self):
+    def test_show_subordinate_status(self):
         m = MySQLServer(self.MYSQL_HOSTNAME, self.MYSQL_PORT, self.MYSQL_USER, self.MYSQL_PASSWORD)
-        o = m.show_slave_status(m.connection) # TODO Need a proper MySQL Cluster for this tests to be meaningful
+        o = m.show_subordinate_status(m.connection) # TODO Need a proper MySQL Cluster for this tests to be meaningful
         self.assertTrue(len(o) == 0)
 
-    def test_show_master_status(self):
+    def test_show_main_status(self):
         m = MySQLServer(self.MYSQL_HOSTNAME, self.MYSQL_PORT, self.MYSQL_USER, self.MYSQL_PASSWORD)
-        o =  m.show_master_status(m.connection)
+        o =  m.show_main_status(m.connection)
         self.assertTrue(isinstance(o['position'], int) and o['position'] > 0)
         self.assertEqual(o['file'][:9], "mysql-bin")
 


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.